### PR TITLE
Add site-wide rate limits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@prisma/extension-accelerate": "^1.2.2",
         "@slack/bolt": "^4.2.1",
         "fullstory": "^1.0.10",
+        "limiter": "^3.0.0",
         "next": "15.2.3",
         "next-auth": "^5.0.0-beta.25",
         "prettier": "^3.5.3",
@@ -829,6 +830,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.29.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.29.2", "", { "os": "win32", "cpu": "x64" }, "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA=="],
+
+    "limiter": ["limiter@3.0.0", "", {}, "sha512-hev7DuXojsTFl2YwyzUJMDnZ/qBDd3yZQLSH3aD4tdL1cqfc3TMnoecEJtWFaQFdErZsKoFMBTxF/FBSkgDbEg=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,110 @@
+import { RateLimiter } from 'limiter';
+import { NextRequest, NextResponse } from 'next/server';
+
+const ipLimiters: Map<string, Map<string, { limiter: RateLimiter, lastUsed: number }>> = new Map();
+
+const CLEANUP_INTERVAL = 1000 * 60 * 60;
+const LIMITER_TTL = 1000 * 60 * 60 * 24;
+
+// Change values to what's needed, these are what I think are reasonable
+const rateLimitConfigs = {
+  default: { tokensPerInterval: 60, interval: 'minute' },
+  
+  auth: { tokensPerInterval: 10, interval: 'minute' },
+  
+  admin: { tokensPerInterval: 20, interval: 'minute' },
+  
+  battle: { tokensPerInterval: 30, interval: 'minute' },
+  battleStart: { tokensPerInterval: 10, interval: 'minute' },
+  battleEnd: { tokensPerInterval: 10, interval: 'minute' },
+  battlePause: { tokensPerInterval: 15, interval: 'minute' },
+  battleResume: { tokensPerInterval: 15, interval: 'minute' },
+  battleStatus: { tokensPerInterval: 30, interval: 'minute' },
+  
+  query: { tokensPerInterval: 120, interval: 'minute' }
+};
+
+export type RateLimitType = 
+  | 'default' 
+  | 'auth' 
+  | 'admin' 
+  | 'battle' 
+  | 'battleStart'
+  | 'battleEnd'
+  | 'battlePause'
+  | 'battleResume'
+  | 'battleStatus'
+  | 'query';
+
+if (typeof window === 'undefined') {
+  setInterval(() => {
+    const now = Date.now();
+    
+    for (const [ip, userLimiters] of ipLimiters.entries()) {
+      for (const [key, entry] of userLimiters.entries()) {
+        if (now - entry.lastUsed > LIMITER_TTL) {
+          userLimiters.delete(key);
+        }
+      }
+      
+      if (userLimiters.size === 0) {
+        ipLimiters.delete(ip);
+      }
+    }
+  }, CLEANUP_INTERVAL);
+}
+
+/**
+ * Rate limit middleware for Next.js API routes
+ * @param req Next.js request object
+ * @param type Type of rate limit to apply
+ * @returns NextResponse with 429 status if rate limit exceeded, or null if not
+ */
+export async function rateLimit(
+  req: NextRequest,
+  type: RateLimitType = 'default'
+): Promise<NextResponse | null> {
+  const ip = req.headers.get('x-forwarded-for') || 
+             req.headers.get('x-real-ip') || 
+             'unknown-ip';
+  
+  const path = req.nextUrl.pathname;
+  const limiterKey = `${ip}:${path}`;
+  
+  if (!ipLimiters.has(ip)) {
+    ipLimiters.set(ip, new Map());
+  }
+  
+  const userLimiters = ipLimiters.get(ip)!;
+  
+  if (!userLimiters.has(limiterKey)) {
+    const config = rateLimitConfigs[type];
+    userLimiters.set(
+      limiterKey,
+      {
+        limiter: new RateLimiter({
+          tokensPerInterval: config.tokensPerInterval,
+          interval: config.interval as 'second' | 'minute' | 'hour' | 'day'
+        }),
+        lastUsed: Date.now()
+      }
+    );
+  } else {
+    userLimiters.get(limiterKey)!.lastUsed = Date.now();
+  }
+  
+  const limiter = userLimiters.get(limiterKey)!.limiter;
+  
+  const hasToken = await limiter.tryRemoveTokens(1);
+  
+  if (!hasToken) {
+    return NextResponse.json(
+      { error: 'Too many requests, please try again later.' },
+      { status: 429, headers: {
+        'Retry-After': '60'
+      }}
+    );
+  }
+  
+  return null;
+} 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { rateLimit, RateLimitType } from './lib/rate-limit';
+
+export async function middleware(request: NextRequest) {
+  // Skip non API routes for ratelimiting, this may want to be changed
+  if (!request.nextUrl.pathname.startsWith('/api')) {
+    return NextResponse.next();
+  }
+
+  let rateLimitType: RateLimitType = 'default';
+  const path = request.nextUrl.pathname;
+
+  if (path.startsWith('/api/auth')) {
+    rateLimitType = 'auth';
+  } else if (path.startsWith('/api/admin')) {
+    rateLimitType = 'admin';
+  } else if (path.startsWith('/api/battle')) {
+    rateLimitType = 'battle';
+    
+    if (path.includes('/battle/start')) {
+      rateLimitType = 'battleStart';
+    } else if (path.includes('/battle/end')) {
+      rateLimitType = 'battleEnd';
+    } else if (path.includes('/battle/pause')) {
+      rateLimitType = 'battlePause';
+    } else if (path.includes('/battle/resume')) {
+      rateLimitType = 'battleResume';
+    } else if (path.includes('/battle/status')) {
+      rateLimitType = 'battleStatus';
+    }
+  } else if (
+    path.startsWith('/api/inventory') ||
+    path.startsWith('/api/project') ||
+    path.startsWith('/api/boss') ||
+    path.startsWith('/api/public')
+  ) {
+    rateLimitType = 'query';
+  }
+
+  const rateLimitResult = await rateLimit(request, rateLimitType);
+  
+  if (rateLimitResult) {
+    return rateLimitResult;
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/api/:path*',
+}; 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@prisma/extension-accelerate": "^1.2.2",
     "@slack/bolt": "^4.2.1",
     "fullstory": "^1.0.10",
+    "limiter": "^3.0.0",
     "next": "15.2.3",
     "next-auth": "^5.0.0-beta.25",
     "prettier": "^3.5.3",


### PR DESCRIPTION
Implemented rate limiting using the `limiter` package.

## Notes

- I only implemented rate limiting for the API (this can easily be changed to limiting the entire site, however I am unsure if that is really needed)
- Rate limit states reset on server restart (if this is an issue, a fix would be to add values to a database)
- I put estimated values for reasonable rate limits on the API, but please look over them if you would like to make any changes.
- The functionality was not tested with the frontend application, rather I just tested the API alone. Please test the full app before you merge to make sure everything works as intended.